### PR TITLE
Update IsUnknown to simpler form

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -65,9 +65,7 @@ export type IsNever<T> = [T] extends [never] ? true : false;
 /**
  * Checks if type `T` is the `unknown` type.
  */
-export type IsUnknown<T> = IsNever<T> extends false
-  ? T extends unknown ? unknown extends T ? IsAny<T> extends false ? true : false : false : false
-  : false;
+export type IsUnknown<T> = unknown extends T ? ([T] extends [null] ? false : true) : false;
 
 type TupleMatches<T, U> = Matches<[T], [U]> extends true ? true : false;
 type Matches<T, U> = T extends U ? U extends T ? true : false : false;


### PR DESCRIPTION
Based on compatibility [table](https://www.typescriptlang.org/docs/handbook/type-compatibility.html#any-unknown-object-void-undefined-null-and-never-assignability)
Type `unknown` is only assignable to two types: `unknown` and `any`.
 So first we check if T is `any` or `unknown` : `unknown extends T`, and then filter out `any` because `unknown` is not assignible to other types such as `null` for example.