### PR TITLE
fix: handle recursive types in `IsExact`

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -157,3 +157,19 @@ import {
     | Assert<Has<string | number, number>, true>
     | Assert<Has<string | number, Date>, false>;
 }
+
+// Recursive types
+{
+  type RecursiveType1 = string | number | Date | RecursiveType1[];
+  assert<IsExact<RecursiveType1, RecursiveType1>>(true);
+  type RecursiveType2 = {
+    a: string;
+    prop: RecursiveType2;
+    sub: {
+      prop: RecursiveType2;
+      other: RecursiveType1;
+    };
+  };
+  assert<IsExact<RecursiveType2, RecursiveType2>>(true);
+  assert<IsExact<RecursiveType1, RecursiveType2>>(false);
+}


### PR DESCRIPTION
Hold a union type of all the previously visited types. Bail if revisiting a type.

I think maybe there could be a false positive for this, but it's probably super rare in practice.

Closes #18